### PR TITLE
docs: add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # agents
 Build Telephonic-Grade Voice AI — WebRTC-Ready Framework
 
+## Installation
+
+Requires Python 3.10+.
+
+```bash
+pip install piopiy-ai
+```
+
+Optional extras:
+
+```bash
+pip install "piopiy-ai[openai,anthropic]"
+```
+
 ## Running Tests
 
 To run the test suite, install dependencies and execute:


### PR DESCRIPTION
## Summary
- document Python 3.10+ requirement
- add basic and optional installation commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a587f0a8848331b6b939990640cb1e