### PR TITLE
Add CRM sales example and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,25 @@ To run the test suite, install dependencies and execute:
 pytest
 ```
 
+## Running the Sales CRM Example
+
+1. Install the required dependencies:
+
+```bash
+pip install "piopiy-ai[openai,deepgram,cartesia,silero]" python-dotenv
+```
+
+2. Create a `.env` file with the following variables:
+   - `AGENT_ID`
+   - `AGENT_TOKEN`
+   - `DEEPGRAM_API_KEY`
+   - `OPENAI_API_KEY`
+   - `CARTESIA_API_KEY`
+3. Launch the voice agent:
+
+```bash
+python example/sales.py
+```
+
+This starts a sales-focused CRM assistant ready to handle customer queries.
+

--- a/example/sales.py
+++ b/example/sales.py
@@ -1,4 +1,4 @@
-# user_bot.py
+# Sales CRM voice agent example
 import asyncio
 from piopiy.agent import Agent
 from piopiy.services.cartesia.tts import CartesiaTTSService
@@ -15,8 +15,8 @@ import os
 async def create_session():
    
    voice_agent = VoiceAgent(
-    instructions="You are a friendly AI assistant. Respond naturally and keep your answers conversational.",
-    greeting="Hello, how can I help you today?",
+    instructions="You are a proactive sales assistant for a CRM platform. Help manage customer relationships and promote our offerings.",
+    greeting="Hi there! Looking for a CRM solution? I'm here to help with sales questions.",
    )
 
    stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))


### PR DESCRIPTION
## Summary
- tweak sales example to use a CRM-focused sales prompt
- document how to run the CRM sales example in README
- note required dependencies for the Sales CRM example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17ee7381c8331bd0d489a8b76dfb6