### PR TITLE
docs: expand tts examples

### DIFF
--- a/docs/tts/asyncai.md
+++ b/docs/tts/asyncai.md
@@ -5,9 +5,34 @@ pip install "piopiy-ai[asyncai]"
 export ASYNCAI_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `voice_id`: Voice identifier to use
+- `version`: API version (default `"v1"`)
+- `url`: Endpoint URL (default `"wss://api.async.ai/text_to_speech/websocket/ws"`)
+- `model`: Model name to use (default `"asyncflow_v2.0"`)
+- `sample_rate`: Target audio sample rate
+- `encoding`: Audio encoding (default `"pcm_s16le"`)
+- `container`: Container type (default `"raw"`)
+- `params`: Provider specific options
+- `aggregate_sentences`: Aggregate sentences before synthesis (default `True`)
+
+### Input Parameters
+
+- `language`: Language for synthesis
+
+### Example
+
 ```python
 import os
 from piopiy.services.asyncai.tts import AsyncAITTSService
 
-service = AsyncAITTSService(api_key=os.getenv('ASYNCAI_API_KEY'))
+tts = AsyncAITTSService(
+    api_key=os.getenv("ASYNCAI_API_KEY"),
+    voice_id="VOICE_ID",
+    model="asyncflow_v2.0",
+    sample_rate=24000,
+    encoding="pcm_s16le",
+)
 ```

--- a/docs/tts/aws.md
+++ b/docs/tts/aws.md
@@ -5,9 +5,35 @@ pip install "piopiy-ai[aws]"
 export AWS_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `aws_access_key_id`: AWS access key ID
+- `aws_session_token`: AWS session token
+- `region`: Region for the service
+- `voice_id`: Voice identifier to use (default `"Joanna"`)
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `engine`: TTS engine to use (e.g., "standard", "neural")
+- `language`: Language for synthesis
+- `pitch`: Voice pitch adjustment
+- `rate`: Speech rate adjustment
+- `volume`: Voice volume adjustment
+- `lexicon_names`: Pronunciation lexicons to apply
+
+### Example
+
 ```python
 import os
 from piopiy.services.aws.tts import AWSPollyTTSService
 
-service = AWSPollyTTSService(api_key=os.getenv('AWS_API_KEY'))
+tts = AWSPollyTTSService(
+    api_key=os.getenv("AWS_API_KEY"),
+    region="us-east-1",
+    voice_id="Joanna",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/azure.md
+++ b/docs/tts/azure.md
@@ -5,9 +5,35 @@ pip install "piopiy-ai[azure]"
 export AZURE_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `region`: Region for the service
+- `voice`: Voice identifier to use (default `"en-US-SaraNeural"`)
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `emphasis`: Emphasis level for speech
+- `language`: Language for synthesis
+- `pitch`: Voice pitch adjustment
+- `rate`: Speech rate multiplier
+- `role`: Voice role for expression
+- `style`: Speaking style
+- `style_degree`: Intensity of the speaking style
+- `volume`: Volume level
+
+### Example
+
 ```python
 import os
 from piopiy.services.azure.tts import AzureBaseTTSService
 
-service = AzureBaseTTSService(api_key=os.getenv('AZURE_API_KEY'))
+tts = AzureBaseTTSService(
+    api_key=os.getenv("AZURE_API_KEY"),
+    region="eastus",
+    voice="en-US-SaraNeural",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/cartesia.md
+++ b/docs/tts/cartesia.md
@@ -5,9 +5,37 @@ pip install "piopiy-ai[cartesia]"
 export CARTESIA_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `voice_id`: Voice identifier to use
+- `cartesia_version`: Cartesia API version (default `"2025-04-16"`)
+- `url`: Endpoint URL (default `"wss://api.cartesia.ai/tts/websocket"`)
+- `model`: Model name to use (default `"sonic-2"`)
+- `sample_rate`: Target audio sample rate
+- `encoding`: Audio encoding (default `"pcm_s16le"`)
+- `container`: Container type (default `"raw"`)
+- `params`: Provider specific options
+- `text_aggregator`: Custom text aggregator
+- `aggregate_sentences`: Aggregate sentences before synthesis (default `True`)
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `speed`: Voice speed control
+- `emotion`: List of emotion tags (deprecated)
+
+### Example
+
 ```python
 import os
 from piopiy.services.cartesia.tts import CartesiaTTSService
 
-service = CartesiaTTSService(api_key=os.getenv('CARTESIA_API_KEY'))
+tts = CartesiaTTSService(
+    api_key=os.getenv("CARTESIA_API_KEY"),
+    voice_id="VOICE_ID",
+    model="sonic-2",
+    sample_rate=24000,
+    encoding="pcm_s16le",
+)
 ```

--- a/docs/tts/deepgram.md
+++ b/docs/tts/deepgram.md
@@ -5,9 +5,28 @@ pip install "piopiy-ai[deepgram]"
 export DEEPGRAM_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `voice`: Voice identifier to use (default `"aura-2-helena-en"`)
+- `base_url`: Override API base URL (default `""`)
+- `sample_rate`: Target audio sample rate
+- `encoding`: Audio encoding (default `"linear16"`)
+
+### Input Parameters
+
+None
+
+### Example
+
 ```python
 import os
 from piopiy.services.deepgram.tts import DeepgramTTSService
 
-service = DeepgramTTSService(api_key=os.getenv('DEEPGRAM_API_KEY'))
+tts = DeepgramTTSService(
+    api_key=os.getenv("DEEPGRAM_API_KEY"),
+    voice="aura-2-helena-en",
+    sample_rate=24000,
+    encoding="linear16",
+)
 ```

--- a/docs/tts/elevenlabs.md
+++ b/docs/tts/elevenlabs.md
@@ -5,9 +5,39 @@ pip install "piopiy-ai[elevenlabs]"
 export ELEVENLABS_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `voice_id`: Voice identifier to use
+- `model`: Model name to use (default `"eleven_turbo_v2_5"`)
+- `url`: Endpoint URL (default `"wss://api.elevenlabs.io"`)
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+- `aggregate_sentences`: Aggregate sentences before synthesis (default `True`)
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `stability`: Voice stability control
+- `similarity_boost`: Similarity boost level
+- `style`: Voice style control
+- `use_speaker_boost`: Enable speaker boost
+- `speed`: Voice speed control
+- `auto_mode`: Enable automatic mode optimization
+- `enable_ssml_parsing`: Enable SSML parsing
+- `enable_logging`: Enable provider logging
+- `apply_text_normalization`: Text normalization mode
+
+### Example
+
 ```python
 import os
 from piopiy.services.elevenlabs.tts import ElevenLabsTTSService
 
-service = ElevenLabsTTSService(api_key=os.getenv('ELEVENLABS_API_KEY'))
+tts = ElevenLabsTTSService(
+    api_key=os.getenv("ELEVENLABS_API_KEY"),
+    voice_id="VOICE_ID",
+    model="eleven_turbo_v2_5",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/fish.md
+++ b/docs/tts/fish.md
@@ -5,9 +5,34 @@ pip install "piopiy-ai[fish]"
 export FISH_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `reference_id`: Reference audio identifier
+- `model`: Model name to use
+- `model_id`: Model identifier to use (default `"speech-1.5"`)
+- `output_format`: Output audio format (default `"pcm"`)
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `latency`: Latency mode ("normal" or "balanced")
+- `normalize`: Whether to normalize audio output
+- `prosody_speed`: Speech speed multiplier
+- `prosody_volume`: Volume adjustment in dB
+
+### Example
+
 ```python
 import os
 from piopiy.services.fish.tts import FishAudioTTSService
 
-service = FishAudioTTSService(api_key=os.getenv('FISH_API_KEY'))
+tts = FishAudioTTSService(
+    api_key=os.getenv("FISH_API_KEY"),
+    reference_id="VOICE_ID",
+    model_id="speech-1.5",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/google.md
+++ b/docs/tts/google.md
@@ -5,9 +5,33 @@ pip install "piopiy-ai[google]"
 export GOOGLE_API_KEY=your_key
 ```
 
+### Parameters
+
+- `credentials`: Parameter
+- `credentials_path`: Parameter
+- `voice_id`: Voice identifier to use (default `"en-US-Chirp3-HD-Charon"`)
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `pitch`: Voice pitch adjustment
+- `rate`: Speaking rate adjustment
+- `volume`: Volume adjustment
+- `emphasis`: Emphasis level for the text
+- `language`: Language for synthesis
+- `gender`: Voice gender preference
+- `google_style`: Google-specific voice style
+
+### Example
+
 ```python
 import os
 from piopiy.services.google.tts import GoogleHttpTTSService
 
-service = GoogleHttpTTSService(api_key=os.getenv('GOOGLE_API_KEY'))
+tts = GoogleHttpTTSService(
+    credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
+    voice_id="en-US-Chirp3-HD-Charon",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/groq.md
+++ b/docs/tts/groq.md
@@ -5,9 +5,30 @@ pip install "piopiy-ai[groq]"
 export GROQ_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `output_format`: Output audio format (default `"wav"`)
+- `params`: Provider specific options
+- `model_name`: Model name to use (default `"playai-tts"`)
+- `voice_id`: Voice identifier to use (default `"Celeste-PlayAI"`)
+- `sample_rate`: Target audio sample rate (default `GROQ_SAMPLE_RATE`)
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `speed`: Speech speed multiplier
+
+### Example
+
 ```python
 import os
 from piopiy.services.groq.tts import GroqTTSService
 
-service = GroqTTSService(api_key=os.getenv('GROQ_API_KEY'))
+tts = GroqTTSService(
+    api_key=os.getenv("GROQ_API_KEY"),
+    voice_id="Celeste-PlayAI",
+    model_name="playai-tts",
+    output_format="wav",
+)
 ```

--- a/docs/tts/inworld.md
+++ b/docs/tts/inworld.md
@@ -5,9 +5,31 @@ pip install "piopiy-ai[inworld]"
 export INWORLD_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `aiohttp_session`: Reuse existing aiohttp session
+- `voice_id`: Voice identifier to use (default `"Ashley"`)
+- `model`: Model name to use (default `"inworld-tts-1"`)
+- `streaming`: Enable streaming mode (default `True`)
+- `sample_rate`: Target audio sample rate
+- `encoding`: Audio encoding (default `"LINEAR16"`)
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `temperature`: Voice temperature control
+
+### Example
+
 ```python
 import os
 from piopiy.services.inworld.tts import InworldTTSService
 
-service = InworldTTSService(api_key=os.getenv('INWORLD_API_KEY'))
+tts = InworldTTSService(
+    api_key=os.getenv("INWORLD_API_KEY"),
+    voice_id="Ashley",
+    model="inworld-tts-1",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/lmnt.md
+++ b/docs/tts/lmnt.md
@@ -5,9 +5,28 @@ pip install "piopiy-ai[lmnt]"
 export LMNT_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `voice_id`: Voice identifier to use
+- `sample_rate`: Target audio sample rate
+- `language`: Language selection (default `Language.EN`)
+- `model`: Model name to use (default `"blizzard"`)
+
+### Input Parameters
+
+None
+
+### Example
+
 ```python
 import os
 from piopiy.services.lmnt.tts import LmntTTSService
 
-service = LmntTTSService(api_key=os.getenv('LMNT_API_KEY'))
+tts = LmntTTSService(
+    api_key=os.getenv("LMNT_API_KEY"),
+    voice_id="VOICE_ID",
+    model="blizzard",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/minimax.md
+++ b/docs/tts/minimax.md
@@ -1,13 +1,41 @@
-# Minimax TTS
+# MiniMax TTS
 
 ```bash
 pip install "piopiy-ai[minimax]"
 export MINIMAX_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `base_url`: Override API base URL (default `"https://api.minimax.io/v1/t2a_v2"`)
+- `group_id`: Group identifier
+- `model`: Model name to use (default `"speech-02-turbo"`)
+- `voice_id`: Voice identifier to use (default `"Calm_Woman"`)
+- `aiohttp_session`: Reuse existing aiohttp session
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `speed`: Speech speed (0.5 to 2.0)
+- `volume`: Speech volume (0 to 10)
+- `pitch`: Pitch adjustment (-12 to 12)
+- `emotion`: Emotional tone (e.g., "happy", "sad")
+- `english_normalization`: Enable English text normalization
+
+### Example
+
 ```python
 import os
 from piopiy.services.minimax.tts import MiniMaxHttpTTSService
 
-service = MiniMaxHttpTTSService(api_key=os.getenv('MINIMAX_API_KEY'))
+tts = MiniMaxHttpTTSService(
+    api_key=os.getenv("MINIMAX_API_KEY"),
+    group_id="GROUP_ID",
+    model="speech-02-turbo",
+    voice_id="Calm_Woman",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/neuphonic.md
+++ b/docs/tts/neuphonic.md
@@ -5,9 +5,31 @@ pip install "piopiy-ai[neuphonic]"
 export NEUPHONIC_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `voice_id`: Voice identifier to use
+- `url`: Endpoint URL (default `"wss://api.neuphonic.com"`)
+- `sample_rate`: Target audio sample rate (default `22050`)
+- `encoding`: Audio encoding (default `"pcm_linear"`)
+- `params`: Provider specific options
+- `aggregate_sentences`: Aggregate sentences before synthesis (default `True`)
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `speed`: Speech speed multiplier
+
+### Example
+
 ```python
 import os
 from piopiy.services.neuphonic.tts import NeuphonicTTSService
 
-service = NeuphonicTTSService(api_key=os.getenv('NEUPHONIC_API_KEY'))
+tts = NeuphonicTTSService(
+    api_key=os.getenv("NEUPHONIC_API_KEY"),
+    voice_id="VOICE_ID",
+    sample_rate=22050,
+    encoding="pcm_linear",
+)
 ```

--- a/docs/tts/openai.md
+++ b/docs/tts/openai.md
@@ -5,9 +5,29 @@ pip install "piopiy-ai[openai]"
 export OPENAI_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `base_url`: Override API base URL
+- `voice`: Voice identifier to use (default `"alloy"`)
+- `model`: Model name to use (default `"gpt-4o-mini-tts"`)
+- `sample_rate`: Target audio sample rate
+- `instructions`: Guidance for synthesis
+
+### Input Parameters
+
+None
+
+### Example
+
 ```python
 import os
 from piopiy.services.openai.tts import OpenAITTSService
 
-service = OpenAITTSService(api_key=os.getenv('OPENAI_API_KEY'))
+tts = OpenAITTSService(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    voice="alloy",
+    model="gpt-4o-mini-tts",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/piper.md
+++ b/docs/tts/piper.md
@@ -5,9 +5,26 @@ pip install "piopiy-ai[piper]"
 export PIPER_API_KEY=your_key
 ```
 
+### Parameters
+
+- `base_url`: Override API base URL
+- `aiohttp_session`: Reuse existing aiohttp session
+- `sample_rate`: Target audio sample rate
+
+### Input Parameters
+
+None
+
+### Example
+
 ```python
-import os
+import aiohttp
 from piopiy.services.piper.tts import PiperTTSService
 
-service = PiperTTSService(api_key=os.getenv('PIPER_API_KEY'))
+session = aiohttp.ClientSession()
+tts = PiperTTSService(
+    base_url="http://localhost:5002",
+    aiohttp_session=session,
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/playht.md
+++ b/docs/tts/playht.md
@@ -5,9 +5,32 @@ pip install "piopiy-ai[playht]"
 export PLAYHT_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `user_id`: User identifier
+- `voice_url`: Voice URL
+- `voice_engine`: Voice engine ID (default `"Play3.0-mini"`)
+- `sample_rate`: Target audio sample rate
+- `output_format`: Output audio format (default `"wav"`)
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `speed`: Speech speed multiplier
+- `seed`: Random seed for voice consistency
+
+### Example
+
 ```python
 import os
 from piopiy.services.playht.tts import PlayHTTTSService
 
-service = PlayHTTTSService(api_key=os.getenv('PLAYHT_API_KEY'))
+tts = PlayHTTTSService(
+    api_key=os.getenv("PLAYHT_API_KEY"),
+    user_id="USER_ID",
+    voice_engine="Play3.0-mini",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/rime.md
+++ b/docs/tts/rime.md
@@ -5,9 +5,35 @@ pip install "piopiy-ai[rime]"
 export RIME_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `voice_id`: Voice identifier to use
+- `url`: Endpoint URL (default `"wss://users.rime.ai/ws2"`)
+- `model`: Model name to use (default `"mistv2"`)
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+- `text_aggregator`: Custom text aggregator
+- `aggregate_sentences`: Aggregate sentences before synthesis (default `True`)
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `speed_alpha`: Speech speed multiplier
+- `reduce_latency`: Reduce latency at potential quality cost
+- `pause_between_brackets`: Add pauses between bracketed content
+- `phonemize_between_brackets`: Phonemize bracketed content
+
+### Example
+
 ```python
 import os
 from piopiy.services.rime.tts import RimeTTSService
 
-service = RimeTTSService(api_key=os.getenv('RIME_API_KEY'))
+tts = RimeTTSService(
+    api_key=os.getenv("RIME_API_KEY"),
+    voice_id="VOICE_ID",
+    model="mistv2",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/riva.md
+++ b/docs/tts/riva.md
@@ -5,9 +5,33 @@ pip install "piopiy-ai[riva]"
 export RIVA_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `server`: Parameter (default `"grpc.nvcf.nvidia.com:443"`)
+- `voice_id`: Voice identifier to use (default `"Magpie-Multilingual.EN-US.Ray"`)
+- `sample_rate`: Target audio sample rate
+- `model_function_map`: Parameter (default `{
+            "function_id": "877104f7-e885-42b9-8de8-f6e4c6303969",
+            "model_name": "magpie-tts-multilingual",
+        }`)
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `language`: Language code for synthesis
+- `quality`: Audio quality setting
+
+### Example
+
 ```python
 import os
 from piopiy.services.riva.tts import RivaTTSService
 
-service = RivaTTSService(api_key=os.getenv('RIVA_API_KEY'))
+tts = RivaTTSService(
+    api_key=os.getenv("RIVA_API_KEY"),
+    server="grpc.nvcf.nvidia.com:443",
+    voice_id="Magpie-Multilingual.EN-US.Ray",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/sarvam.md
+++ b/docs/tts/sarvam.md
@@ -5,9 +5,35 @@ pip install "piopiy-ai[sarvam]"
 export SARVAM_API_KEY=your_key
 ```
 
+### Parameters
+
+- `api_key`: API key for authentication
+- `aiohttp_session`: Reuse existing aiohttp session
+- `voice_id`: Voice identifier to use (default `"anushka"`)
+- `model`: Model name to use (default `"bulbul:v2"`)
+- `base_url`: Override API base URL (default `"https://api.sarvam.ai"`)
+- `sample_rate`: Target audio sample rate
+- `params`: Provider specific options
+
+### Input Parameters
+
+- `language`: Language for synthesis
+- `pitch`: Voice pitch adjustment
+- `pace`: Speech pace multiplier
+- `loudness`: Volume multiplier
+- `enable_preprocessing`: Enable text preprocessing
+
+### Example
+
 ```python
 import os
 from piopiy.services.sarvam.tts import SarvamHttpTTSService
 
-service = SarvamHttpTTSService(api_key=os.getenv('SARVAM_API_KEY'))
+tts = SarvamHttpTTSService(
+    api_key=os.getenv("SARVAM_API_KEY"),
+    voice_id="anushka",
+    model="bulbul:v2",
+    base_url="https://api.sarvam.ai",
+    sample_rate=24000,
+)
 ```

--- a/docs/tts/xtts.md
+++ b/docs/tts/xtts.md
@@ -5,9 +5,28 @@ pip install "piopiy-ai[xtts]"
 export XTTS_API_KEY=your_key
 ```
 
+### Parameters
+
+- `voice_id`: Voice identifier to use
+- `base_url`: Override API base URL
+- `aiohttp_session`: Reuse existing aiohttp session
+- `language`: Language selection (default `Language.EN`)
+- `sample_rate`: Target audio sample rate
+
+### Input Parameters
+
+None
+
+### Example
+
 ```python
 import os
 from piopiy.services.xtts.tts import XTTSService
 
-service = XTTSService(api_key=os.getenv('XTTS_API_KEY'))
+tts = XTTSService(
+    api_key=os.getenv("XTTS_API_KEY"),
+    voice_id="VOICE_ID",
+    language="EN",
+    sample_rate=24000,
+)
 ```


### PR DESCRIPTION
## Summary
- expand example blocks so each TTS guide shows service initialization with optional parameters
- document input parameter options for each TTS provider

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b19a180da48331b9409de18e29ea9c