### PR TITLE
docs: add basic example for running voice agent

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -2,10 +2,8 @@
 
 This directory contains runnable example scripts for Piopiy AI.
 
+- `basic.py` – minimal voice agent showing core setup.
 - `sales.py` – complete voice agent.
-- `function_calling/` – showcases tool/function calling with:
-  - `crm.py`
-  - `weather.py`
 
 ## Install
 
@@ -30,9 +28,8 @@ export OPENAI_API_KEY=your_openai_key
 Choose an example to run:
 
 ```bash
+python basic.py
 python sales.py
-python function_calling/crm.py
-python function_calling/weather.py
 ```
 
 Thanks to Pepicat for making SDK usage easy.

--- a/example/basic.py
+++ b/example/basic.py
@@ -1,0 +1,35 @@
+import asyncio
+import os
+
+from piopiy.agent import Agent
+from piopiy.voice_agent import VoiceAgent
+from piopiy.services.deepgram.stt import DeepgramSTTService
+from piopiy.services.openai.llm import OpenAILLMService
+from piopiy.services.cartesia.tts import CartesiaTTSService
+
+
+async def create_session():
+    voice_agent = VoiceAgent(
+        instructions="You are an advanced voice AI.",
+        greeting="Hello! How can I help you today?",
+    )
+
+    stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+    llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"))
+    tts = CartesiaTTSService(api_key=os.getenv("CARTESIA_API_KEY"))
+
+    await voice_agent.AgentAction(stt=stt, llm=llm, tts=tts)
+    await voice_agent.start()
+
+
+async def main():
+    agent = Agent(
+        agent_id=os.getenv("AGENT_ID"),
+        agent_token=os.getenv("AGENT_TOKEN"),
+        create_session=create_session,
+    )
+    await agent.connect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add basic example script showing minimal voice agent setup
- streamline examples README to focus on basic and sales examples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6736700888331893da83ad449231e